### PR TITLE
Switch into container-based Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python: 2.7
 
+sudo: false
+
 cache:
   directories:
     - $HOME/.pip-cache/


### PR DESCRIPTION
At https://travis-ci.org/dominicrodger/django-tinycontent/jobs/73778385 we have:
>  This job ran on our legacy infrastructure. Please read our docs on how to upgrade

See http://docs.travis-ci.com/user/migrating-from-legacy/ .