### PR TITLE
Tests update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-python: 2.7
+python: 3.5
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,13 @@ env:
   - TOX_ENV=docs
   - TOX_ENV=flake8
 
+matrix:
+  allow_failures:
+    - env: TOX_ENV=py27-master
+    - env: TOX_ENV=py34-master
+    - env: TOX_ENV=py35-master
+  fast_finish: true
+
 install:
   - pip install tox coveralls --cache-dir $HOME/.pip-cache
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,24 @@ cache:
     - $HOME/.pip-cache/
 
 env:
+  - TOX_ENV=py27-master
+  - TOX_ENV=py27-1.9.X
   - TOX_ENV=py27-1.8.X
   - TOX_ENV=py27-1.7.X
   - TOX_ENV=py27-1.6.X
   - TOX_ENV=py27-1.5.X
+  - TOX_ENV=py34-master
+  - TOX_ENV=py34-1.9.X
   - TOX_ENV=py34-1.8.X
   - TOX_ENV=py34-1.7.X
   - TOX_ENV=py34-1.6.X
   - TOX_ENV=py34-1.5.X
+  - TOX_ENV=py35-master
+  - TOX_ENV=py35-1.9.X
+  - TOX_ENV=py35-1.8.X
+  - TOX_ENV=py35-1.7.X
+  - TOX_ENV=py35-1.6.X
+  - TOX_ENV=py35-1.5.X
   - TOX_ENV=docs
   - TOX_ENV=flake8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,6 @@ env:
   - TOX_ENV=py35-master
   - TOX_ENV=py35-1.9.X
   - TOX_ENV=py35-1.8.X
-  - TOX_ENV=py35-1.7.X
-  - TOX_ENV=py35-1.6.X
-  - TOX_ENV=py35-1.5.X
   - TOX_ENV=docs
   - TOX_ENV=flake8
 

--- a/setup.py
+++ b/setup.py
@@ -45,10 +45,10 @@ setup(
         "Programming Language :: Python :: 3.4",
     ],
     tests_require=(
-        "mock==1.0.1",
-        "pytest==2.7.1",
-        "pytest-cov==1.8.1",
-        "pytest-django==2.8.0",
+        "mock==2.0.0",
+        "pytest==2.9.1",
+        "pytest-cov==2.2.1",
+        "pytest-django==2.9.1",
     ),
     cmdclass={'test': PyTest},
 )

--- a/setup.py
+++ b/setup.py
@@ -50,5 +50,5 @@ setup(
         "pytest-cov==1.8.1",
         "pytest-django==2.8.0",
     ),
-    cmdclass = {'test': PyTest},
+    cmdclass={'test': PyTest},
 )

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -1,4 +1,8 @@
 import django
+import pytest
+
+import mock
+from tinycontent.models import TinyContent
 
 # Django 1.5 doesn't have CaptureQueriesContext, and adding support
 # for checking query counts is irritating, so let's just skip those
@@ -8,10 +12,6 @@ SKIP_CACHE_TESTS = django.VERSION < (1, 6)
 if not SKIP_CACHE_TESTS:
     from django.db import DEFAULT_DB_ALIAS, connections
     from django.test.utils import CaptureQueriesContext
-
-import mock
-import pytest
-from tinycontent.models import TinyContent
 
 
 class FakeCache(object):

--- a/tests/test_custom_filters.py
+++ b/tests/test_custom_filters.py
@@ -1,13 +1,13 @@
 import os
-import pytest
 import sys
 
-# Needed for the custom filter tests
-sys.path.append(os.path.dirname(__file__))
-
+import pytest
 from django.core.exceptions import ImproperlyConfigured
 
 from .utils import render_template
+
+# Needed for the custom filter tests
+sys.path.append(os.path.dirname(__file__))
 
 
 @pytest.mark.django_db

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ basepython =
     py35: python3.5
 deps =
     coverage==3.7.1
-    master: https://github.com/watchdogpolska/django-tinycontent/archive/master.tar.gz
+    master: https://github.com/django/django/archive/master.tar.gz
     1.9.X: Django>=1.9,<1.10
     1.8.X: Django>=1.8,<1.9
     1.7.X: Django>=1.7,<1.8

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34}-{1.8.X,1.7.X,1.6.X,1.5.X},docs,flake8
+envlist = {py27,py34,py35}-{master,1.9.X,1.8.X,1.7.X,1.6.X,1.5.X},docs,flake8
 
 [flake8]
 exclude = tinycontent/migrations/*
@@ -10,8 +10,11 @@ commands=
 basepython =
     py27: python2.7
     py34: python3.4
+    py35: python3.5
 deps =
     coverage==3.7.1
+    master: https://github.com/watchdogpolska/django-tinycontent/archive/master.tar.gz
+    1.9.X: Django>=1.9,<1.10
     1.8.X: Django>=1.8,<1.9
     1.7.X: Django>=1.7,<1.8
     1.6.X: Django>=1.6,<1.7

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py34,py35}-{master,1.9.X,1.8.X,1.7.X,1.6.X,1.5.X},docs,flake8
+envlist = {py27,py34}-{master,1.9.X,1.8.X,1.7.X,1.6.X,1.5.X},{py35-master,1.9.X,1.8.X},docs,flake8
 
 [flake8]
 exclude = tinycontent/migrations/*


### PR DESCRIPTION
Hello,

Django 1.9 was releases, so  I recommend add tests over them.

Python 3.5 was releases to Ubuntu (very popular Linux distribution even on server) as default python 3, so I recommend add tests over them.

We want have forward compatibility, so I recommend add tests over django-master. It was mark as `allow_failures` so it will not cause difficulties during pull requests.

Greetings,
